### PR TITLE
Cache Maven artifacts between builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,13 +20,26 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+
     - name: Install playshogi-library-common
       run: mvn -B install --file playshogi-library-common/pom.xml
+
     - name: Install playshogi-library-shogi
       run: mvn -B install --file playshogi-library-shogi/pom.xml
+
     - name: Install playshogi-library-shogi-files
       run: mvn -B install --file playshogi-library-shogi-files/pom.xml
+
     - name: Install playshogi-library-database
       run: mvn -B install --file playshogi-library-database/pom.xml
+
     - name: Build playshogi-gwt-mvn
       run: mvn -B package --file playshogi-website-gwt-mvn/pom.xml
+


### PR DESCRIPTION
GitHub can cache Maven artifacts for 7 days, which saves time during builds:
https://docs.github.com/en/actions/language-and-framework-guides/building-and-testing-java-with-maven
https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows