### PR TITLE
Validate unpromotion moves (fix Tellmarch/playshogi#27)

### DIFF
--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/formats/kif/KifMoveConverter.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/formats/kif/KifMoveConverter.java
@@ -77,8 +77,8 @@ public class KifMoveConverter {
             if (shogiPosition.getShogiBoardState().getPieceAt(toSquare) == null) {
                 return new NormalMove(piece, fromSquare, toSquare, promote);
             } else {
-                return new CaptureMove(piece, fromSquare, toSquare, promote,
-                        shogiPosition.getShogiBoardState().getPieceAt(toSquare));
+                Piece capturedPiece = shogiPosition.getShogiBoardState().getPieceAt(toSquare);
+                return new CaptureMove(piece, fromSquare, toSquare, capturedPiece, promote);
             }
 
         } else {

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/formats/usf/UsfMoveConverter.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/formats/usf/UsfMoveConverter.java
@@ -64,7 +64,7 @@ public class UsfMoveConverter {
             if (capturedPiece == null) {
                 return new NormalMove(piece, Square.of(col1, row1), Square.of(col2, row2), promotion);
             } else {
-                return new CaptureMove(piece, Square.of(col1, row1), Square.of(col2, row2), promotion, capturedPiece);
+                return new CaptureMove(piece, Square.of(col1, row1), Square.of(col2, row2), capturedPiece, promotion);
             }
         }
     }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/moves/CaptureMove.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/moves/CaptureMove.java
@@ -7,10 +7,25 @@ public class CaptureMove extends NormalMove {
 
     private final Piece capturedPiece;
 
-    public CaptureMove(final Piece piece, final Square fromSquare, final Square toSquare, final boolean promote,
-                       final Piece capturedPiece) {
-        super(piece, fromSquare, toSquare, promote);
+    public CaptureMove(Piece piece, Square fromSquare, Square toSquare, Piece capturedPiece) {
+        super(piece, fromSquare, toSquare);
         this.capturedPiece = capturedPiece;
+    }
+
+    public CaptureMove(Piece piece, Square fromSquare, Square toSquare, Piece capturedPiece,
+                       Piece promotionPiece) {
+        super(piece, fromSquare, toSquare, promotionPiece);
+        this.capturedPiece = capturedPiece;
+    }
+
+    @Deprecated
+    public CaptureMove(Piece piece, Square fromSquare, Square toSquare, Piece capturedPiece, boolean promote) {
+        this(piece, fromSquare, toSquare, capturedPiece, promote ? piece.getPromotedPiece() : null);
+    }
+
+    @Override
+    public CaptureMove withPromotionPiece(Piece promotionPiece) {
+        return new CaptureMove(piece, fromSquare, toSquare, capturedPiece, promotionPiece);
     }
 
     public Piece getCapturedPiece() {

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/moves/NormalMove.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/moves/NormalMove.java
@@ -3,19 +3,34 @@ package com.playshogi.library.shogi.models.moves;
 import com.playshogi.library.models.Square;
 import com.playshogi.library.shogi.models.Piece;
 
+import java.util.Optional;
+
 public class NormalMove extends ShogiMove implements ToSquareMove {
 
-    private final Piece piece;
-    private final Square fromSquare;
-    private final Square toSquare;
-    private boolean promote;
+    protected final Piece piece;
+    protected final Square fromSquare;
+    protected final Square toSquare;
+    protected final Piece promotionPiece;
 
-    public NormalMove(final Piece piece, final Square fromSquare, final Square toSquare, final boolean promote) {
+    public NormalMove(Piece piece, Square fromSquare, Square toSquare) {
+        this(piece, fromSquare, toSquare, null);
+    }
+
+    public NormalMove(Piece piece, Square fromSquare, Square toSquare, Piece promotionPiece) {
         super(piece.isSentePiece());
         this.piece = piece;
         this.fromSquare = fromSquare;
         this.toSquare = toSquare;
-        this.promote = promote;
+        this.promotionPiece = promotionPiece;
+    }
+
+    @Deprecated
+    public NormalMove(Piece piece, Square fromSquare, Square toSquare, boolean promote) {
+        this(piece, fromSquare, toSquare, promote ? piece.getPromotedPiece() : null);
+    }
+
+    public NormalMove withPromotionPiece(Piece promotionPiece) {
+        return new NormalMove(piece, fromSquare, toSquare, promotionPiece);
     }
 
     public Piece getPiece() {
@@ -32,12 +47,11 @@ public class NormalMove extends ShogiMove implements ToSquareMove {
     }
 
     public boolean isPromote() {
-        return promote;
+        return promotionPiece != null;
     }
 
-    public void setPromote(final boolean promote) {
-        this.promote = promote;
-
+    public Optional<Piece> getPromotionPiece() {
+        return Optional.ofNullable(promotionPiece);
     }
 
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/ShogiRulesEngine.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/ShogiRulesEngine.java
@@ -179,13 +179,11 @@ public class ShogiRulesEngine implements GameRulesEngine<ShogiPosition> {
     /**
      * Doesn't check if the move is legal
      */
-    public boolean canMoveWithUnpromotion(final ShogiPosition position, final Move move) {
+    public boolean canMoveWithoutPromotion(final ShogiPosition position, final Move move) {
         if (move instanceof NormalMove) {
+
             NormalMove normalMove = (NormalMove) move;
             if (normalMove.getPiece().isPromoted()) {
-                return false;
-            }
-            if (!normalMove.getPiece().canPromote()) {
                 return true;
             }
 
@@ -269,7 +267,7 @@ public class ShogiRulesEngine implements GameRulesEngine<ShogiPosition> {
                     Piece targetPiece = position.getPieceAt(targetSquare);
                     if (targetPiece != null) { //check if it is a capturing move
                         NormalMove capture = new CaptureMove(piece, everySquare, targetSquare, false, targetPiece);
-                        if (canMoveWithUnpromotion(position, capture)) {
+                        if (canMoveWithoutPromotion(position, capture)) {
                              result.add(capture);
                         }
                         if (canMoveWithPromotion(position, capture)) {//if can promote, capture with promotion
@@ -278,7 +276,7 @@ public class ShogiRulesEngine implements GameRulesEngine<ShogiPosition> {
 
                     } else {
                         NormalMove move = new NormalMove(piece, everySquare, targetSquare, false);
-                        if (canMoveWithUnpromotion(position, result.get(result.size() - 1))) {
+                        if (canMoveWithoutPromotion(position, result.get(result.size() - 1))) {
                             result.add(move);
                         }
                         if (canMoveWithPromotion(position, move)) {//if can promote, move with promotion

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/BishopMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/BishopMovement.java
@@ -29,4 +29,9 @@ public class BishopMovement implements PieceMovement {
         return true;
     }
 
+    @Override
+    public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
+        return true;
+    }
+
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/GoldMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/GoldMovement.java
@@ -15,4 +15,9 @@ public class GoldMovement extends AbstractPieceMovement {
     public boolean isDropValid(final ShogiBoardState boardState, final Square to) {
         return true;
     }
+
+    @Override
+    public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
+        return true;
+    }
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/GoldMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/GoldMovement.java
@@ -20,4 +20,5 @@ public class GoldMovement extends AbstractPieceMovement {
     public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
         return true;
     }
+
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/KingMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/KingMovement.java
@@ -15,4 +15,9 @@ public class KingMovement extends AbstractPieceMovement {
     public boolean isDropValid(final ShogiBoardState boardState, final Square to) {
         return false;
     }
+
+    @Override
+    public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
+        return true;
+    }
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/KingMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/KingMovement.java
@@ -20,4 +20,5 @@ public class KingMovement extends AbstractPieceMovement {
     public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
         return true;
     }
+
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/KnightMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/KnightMovement.java
@@ -41,4 +41,9 @@ public class KnightMovement implements PieceMovement {
         return to.getRow() >= ShogiBoardState.FIRST_ROW + 2;
     }
 
+    @Override
+    public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
+        return isDropValid(boardState, to);
+    }
+
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/LanceMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/LanceMovement.java
@@ -36,4 +36,9 @@ public class LanceMovement implements PieceMovement {
         return to.getRow() != ShogiBoardState.FIRST_ROW;
     }
 
+    @Override
+    public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
+        return isDropValid(boardState, to);
+    }
+
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PawnMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PawnMovement.java
@@ -32,6 +32,11 @@ public class PawnMovement implements PieceMovement {
                 && !checkMatePawnMove(position, to);
     }
 
+    @Override
+    public boolean isUnpromoteValid(final ShogiBoardState position, final Square to) {
+        return to.getRow() != ShogiBoardState.FIRST_ROW;
+    }
+
     private boolean checkMatePawnMove(final ShogiBoardState position, final Square to) {
         // TODO Auto-generated method stub
         return false;

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PieceMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PieceMovement.java
@@ -19,4 +19,9 @@ public interface PieceMovement {
      */
     boolean isDropValid(ShogiBoardState boardState, Square to);
 
+    /**
+     * Does not need to validate the empty square at to.
+     */
+    boolean isUnpromoteValid(ShogiBoardState boardState, Square to);
+
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PieceMovementsUtils.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PieceMovementsUtils.java
@@ -40,4 +40,5 @@ public class PieceMovementsUtils {
             return null;
         }
     }
+
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovement.java
@@ -33,4 +33,9 @@ public class PromotedBishopMovement extends AbstractPieceMovement {
     public boolean isDropValid(final ShogiBoardState boardState, final Square to) {
         return false;
     }
+
+    @Override
+    public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
+        return true;
+    }
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovement.java
@@ -36,6 +36,7 @@ public class PromotedBishopMovement extends AbstractPieceMovement {
 
     @Override
     public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
-        return true;
+        return false;
     }
+
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovement.java
@@ -33,4 +33,9 @@ public class PromotedRookMovement extends AbstractPieceMovement {
     public boolean isDropValid(final ShogiBoardState boardState, final Square to) {
         return false;
     }
+
+    @Override
+    public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
+        return true;
+    }
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovement.java
@@ -36,6 +36,7 @@ public class PromotedRookMovement extends AbstractPieceMovement {
 
     @Override
     public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
-        return true;
+        return false;
     }
+
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/RookMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/RookMovement.java
@@ -60,4 +60,9 @@ public class RookMovement implements PieceMovement {
         return true;
     }
 
+    @Override
+    public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
+        return true;
+    }
+
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/SilverMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/SilverMovement.java
@@ -15,4 +15,9 @@ public class SilverMovement extends AbstractPieceMovement {
     public boolean isDropValid(final ShogiBoardState boardState, final Square to) {
         return true;
     }
+
+    @Override
+    public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
+        return true;
+    }
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/SilverMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/SilverMovement.java
@@ -20,4 +20,5 @@ public class SilverMovement extends AbstractPieceMovement {
     public boolean isUnpromoteValid(final ShogiBoardState boardState, final Square to) {
         return true;
     }
+
 }

--- a/playshogi-website-gwt-mvn/src/main/java/com/playshogi/website/gwt/client/widget/board/PromotionPopupController.java
+++ b/playshogi-website-gwt-mvn/src/main/java/com/playshogi/website/gwt/client/widget/board/PromotionPopupController.java
@@ -9,7 +9,8 @@ import com.playshogi.library.shogi.models.moves.NormalMove;
 class PromotionPopupController {
 
     private final PopupPanel promotionPopupPanel = createPromotionPopupPanel();
-    private NormalMove promotionPopupMove;
+    private NormalMove move;
+    private NormalMove promotionMove;
     private Image unPromotedImage;
     private Image promotedImage;
 
@@ -19,8 +20,10 @@ class PromotionPopupController {
         this.shogiBoard = shogiBoard;
     }
 
-    void showPromotionPopup(final Image image, NormalMove move) {
-        promotionPopupMove = move;
+    void showPromotionPopup(final Image image, NormalMove move, NormalMove promotionMove) {
+        this.move = move;
+        this.promotionMove = promotionMove;
+        // promotionMove contains the promotion piece, so it may be possible to simplify this
         unPromotedImage.setResource(PieceGraphics.getPieceImage(move.getPiece().getPieceType(), false));
         promotedImage.setResource(PieceGraphics.getPieceImage(move.getPiece().getPieceType(), true));
         promotionPopupPanel.setPopupPosition(image.getAbsoluteLeft() - 5, image.getAbsoluteTop() - 5);
@@ -36,12 +39,11 @@ class PromotionPopupController {
         flowPanel.add(unPromotedImage);
         popup.add(flowPanel);
         promotedImage.addClickHandler(clickEvent -> {
-            promotionPopupMove.setPromote(true);
-            shogiBoard.playNormalMoveIfAllowed(promotionPopupMove);
+            shogiBoard.playNormalMoveIfAllowed(promotionMove);
             popup.hide();
         });
         unPromotedImage.addClickHandler(clickEvent -> {
-            shogiBoard.playNormalMoveIfAllowed(promotionPopupMove);
+            shogiBoard.playNormalMoveIfAllowed(move);
             popup.hide();
         });
         return popup;

--- a/playshogi-website-gwt-mvn/src/main/java/com/playshogi/website/gwt/client/widget/board/ShogiBoard.java
+++ b/playshogi-website-gwt-mvn/src/main/java/com/playshogi/website/gwt/client/widget/board/ShogiBoard.java
@@ -270,7 +270,7 @@ public class ShogiBoard extends Composite implements ClickHandler {
                     if (!boardConfiguration.isAllowOnlyLegalMoves() || shogiRulesEngine.isMoveLegalInPosition(position, move)) {
                         playMove(move);
                     }
-                } else {
+                } else if (shogiRulesEngine.getPossibleTargetSquares(position, selectedPiece.getSquare()).contains(getSquare(row, col))) {
                     NormalMove move = new NormalMove(piece, getSquare(selectedPiece.getRow(),
                             selectedPiece.getColumn()), getSquare(row, col), false);
 
@@ -306,10 +306,12 @@ public class ShogiBoard extends Composite implements ClickHandler {
                     unselect();
                 } else {
                     if (selectedPiece != null) {
-                        if (!selectedPiece.isInKomadai() && selectedPiece.getPiece().isSentePiece() != pieceWrapper.getPiece().isSentePiece()) {
+                        if (!selectedPiece.isInKomadai() && selectedPiece.getPiece().isSentePiece() != pieceWrapper.getPiece().isSentePiece() && shogiRulesEngine.getPossibleTargetSquares(position, selectedPiece.getSquare()).contains(pieceWrapper.getSquare())) {
+
                             CaptureMove move = new CaptureMove(selectedPiece.getPiece(),
                                     selectedPiece.getSquare(), pieceWrapper.getSquare(), false,
                                     pieceWrapper.getPiece());
+
                             if (shogiRulesEngine.canMoveWithPromotion(position, move)) {
                                 if (shogiRulesEngine.canMoveWithUnpromotion(position, move)) {
                                     promotionPopupController.showPromotionPopup(pieceWrapper.getImage(), move);

--- a/playshogi-website-gwt-mvn/src/main/java/com/playshogi/website/gwt/client/widget/board/ShogiBoard.java
+++ b/playshogi-website-gwt-mvn/src/main/java/com/playshogi/website/gwt/client/widget/board/ShogiBoard.java
@@ -270,12 +270,12 @@ public class ShogiBoard extends Composite implements ClickHandler {
                     if (!boardConfiguration.isAllowOnlyLegalMoves() || shogiRulesEngine.isMoveLegalInPosition(position, move)) {
                         playMove(move);
                     }
-                } else if (shogiRulesEngine.getPossibleTargetSquares(position, selectedPiece.getSquare()).contains(getSquare(row, col))) {
+                } else if (!boardConfiguration.isAllowOnlyLegalMoves() || shogiRulesEngine.getPossibleTargetSquares(position, selectedPiece.getSquare()).contains(getSquare(row, col))) {
                     NormalMove move = new NormalMove(piece, getSquare(selectedPiece.getRow(),
                             selectedPiece.getColumn()), getSquare(row, col), false);
 
                     if (shogiRulesEngine.canMoveWithPromotion(position, move)) {
-                        if (shogiRulesEngine.canMoveWithUnpromotion(position, move)) {
+                        if (shogiRulesEngine.canMoveWithoutPromotion(position, move)) {
                             promotionPopupController.showPromotionPopup(image, move);
                         } else {
                             move.setPromote(true);
@@ -313,7 +313,7 @@ public class ShogiBoard extends Composite implements ClickHandler {
                                     pieceWrapper.getPiece());
 
                             if (shogiRulesEngine.canMoveWithPromotion(position, move)) {
-                                if (shogiRulesEngine.canMoveWithUnpromotion(position, move)) {
+                                if (shogiRulesEngine.canMoveWithoutPromotion(position, move)) {
                                     promotionPopupController.showPromotionPopup(pieceWrapper.getImage(), move);
                                 } else {
                                     move.setPromote(true);

--- a/playshogi-website-gwt-mvn/src/main/java/com/playshogi/website/gwt/client/widget/board/ShogiBoard.java
+++ b/playshogi-website-gwt-mvn/src/main/java/com/playshogi/website/gwt/client/widget/board/ShogiBoard.java
@@ -275,7 +275,12 @@ public class ShogiBoard extends Composite implements ClickHandler {
                             selectedPiece.getColumn()), getSquare(row, col), false);
 
                     if (shogiRulesEngine.canMoveWithPromotion(position, move)) {
-                        promotionPopupController.showPromotionPopup(image, move);
+                        if (shogiRulesEngine.canMoveWithUnpromotion(position, move)) {
+                            promotionPopupController.showPromotionPopup(image, move);
+                        } else {
+                            move.setPromote(true);
+                            playNormalMoveIfAllowed(move);
+                        }
                     } else {
                         playNormalMoveIfAllowed(move);
                     }
@@ -306,7 +311,12 @@ public class ShogiBoard extends Composite implements ClickHandler {
                                     selectedPiece.getSquare(), pieceWrapper.getSquare(), false,
                                     pieceWrapper.getPiece());
                             if (shogiRulesEngine.canMoveWithPromotion(position, move)) {
-                                promotionPopupController.showPromotionPopup(pieceWrapper.getImage(), move);
+                                if (shogiRulesEngine.canMoveWithUnpromotion(position, move)) {
+                                    promotionPopupController.showPromotionPopup(pieceWrapper.getImage(), move);
+                                } else {
+                                    move.setPromote(true);
+                                    playNormalMoveIfAllowed(move);
+                                }
                             } else {
                                 playNormalMoveIfAllowed(move);
                             }


### PR DESCRIPTION
Move generation now only generates legal unpromote moves, and the client only presents a popup if there is a choice.

Note: Currently I am unable to test this patch.