### PR TITLE
Validate pawn drop checkmate

### DIFF
--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/ShogiRulesEngine.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/ShogiRulesEngine.java
@@ -15,8 +15,6 @@ import com.playshogi.library.shogi.rules.movements.*;
 
 import java.util.*;
 
-import static com.playshogi.library.shogi.models.PieceType.KING;
-
 public class ShogiRulesEngine implements GameRulesEngine<ShogiPosition> {
 
     private static final EnumMap<Piece, PieceMovement> PIECE_MOVEMENTS = new EnumMap<>(Piece.class);
@@ -146,6 +144,10 @@ public class ShogiRulesEngine implements GameRulesEngine<ShogiPosition> {
         if (piece == null) {
             return Collections.emptyList();
         }
+        return getPossibleTargetSquares(position, from, piece);
+    }
+
+    private List<Square> getPossibleTargetSquares(final ShogiPosition position, final Square from, Piece piece) {
         PieceMovement pieceMovement = PIECE_MOVEMENTS.get(piece.getSentePiece());
         if (piece.isSentePiece()) {
             return pieceMovement.getPossibleMoves(position.getShogiBoardState(), from);
@@ -153,7 +155,6 @@ public class ShogiRulesEngine implements GameRulesEngine<ShogiPosition> {
             return Square.opposite(
                     pieceMovement.getPossibleMoves(position.getShogiBoardState().opposite(), from.opposite()));
         }
-
     }
 
     /**
@@ -224,19 +225,22 @@ public class ShogiRulesEngine implements GameRulesEngine<ShogiPosition> {
     }
 
     private boolean isDropMoveLegalInPosition(final ShogiPosition position, final DropMove move) {
-        PieceMovement pieceMovement = PIECE_MOVEMENTS.get(Piece.getPiece(move.getPieceType(), true));
-        boolean result;
-        if (move.isSenteMoving()) {
-            result = pieceMovement.isDropValid(position.getShogiBoardState(), move.getToSquare());
-        } else {
-            result = pieceMovement.isDropValid(position.getShogiBoardState().opposite(), move.getToSquare().opposite());
-        }
+        boolean result = isDropMoveValidInPosition(position, move);
         if (result && move.getPieceType() == PieceType.PAWN) {
             this.playMoveInPosition(position, move);
             result = ! isPositionCheckmate(position, move.isSenteMoving());
             this.undoMoveInPosition(position, move);
         }
         return result;
+    }
+
+    private boolean isDropMoveValidInPosition(final ShogiPosition position, final DropMove move) {
+        PieceMovement pieceMovement = PIECE_MOVEMENTS.get(Piece.getPiece(move.getPieceType(), true));
+        if (move.isSenteMoving()) {
+            return pieceMovement.isDropValid(position.getShogiBoardState(), move.getToSquare());
+        } else {
+            return pieceMovement.isDropValid(position.getShogiBoardState().opposite(), move.getToSquare().opposite());
+        }
     }
 
     private boolean isCaptureMoveLegalInPosition(final ShogiPosition position, final CaptureMove move) {
@@ -330,15 +334,19 @@ public class ShogiRulesEngine implements GameRulesEngine<ShogiPosition> {
     }
 
     public boolean isPositionCheck(final ShogiPosition position, boolean isSente) {
-        for (ShogiMove move : getAllPossibleMoves(position, isSente)) { //generate all possible moves
-            if (move instanceof CaptureMove) { //check only captures
-                CaptureMove captureMove = (CaptureMove) move;
-                if (captureMove.getCapturedPiece().getPieceType() == KING) { //check if captured piece is a king
-                    return true; //check found
-                }
-            }
+        // Find the king square and determine if the king could move like a knight,
+        // would it attack an opposing knight, etc.
+        for (Square square : position.getAllSquares()) {
+            Piece occupant = position.getPieceAt(square);
+            if (occupant != null && occupant.isSentePiece() != isSente && occupant.getPieceType() == PieceType.KING)
+                for (Piece piece : Piece.values())
+                    if (piece.isSentePiece() == occupant.isSentePiece()) {
+                        for (Square to : getPossibleTargetSquares(position, square, piece))
+                            if (position.getPieceAt(to) == piece.opposite())
+                                return true;
+                    }
         }
-        return false;  //no checks for all possible moves
+        return false;
     }
 
     /**

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/ShogiRulesEngine.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/ShogiRulesEngine.java
@@ -225,11 +225,18 @@ public class ShogiRulesEngine implements GameRulesEngine<ShogiPosition> {
 
     private boolean isDropMoveLegalInPosition(final ShogiPosition position, final DropMove move) {
         PieceMovement pieceMovement = PIECE_MOVEMENTS.get(Piece.getPiece(move.getPieceType(), true));
+        boolean result;
         if (move.isSenteMoving()) {
-            return pieceMovement.isDropValid(position.getShogiBoardState(), move.getToSquare());
+            result = pieceMovement.isDropValid(position.getShogiBoardState(), move.getToSquare());
         } else {
-            return pieceMovement.isDropValid(position.getShogiBoardState().opposite(), move.getToSquare().opposite());
+            result = pieceMovement.isDropValid(position.getShogiBoardState().opposite(), move.getToSquare().opposite());
         }
+        if (result && move.getPieceType() == PieceType.PAWN) {
+            this.playMoveInPosition(position, move);
+            result = ! isPositionCheckmate(position, move.isSenteMoving());
+            this.undoMoveInPosition(position, move);
+        }
+        return result;
     }
 
     private boolean isCaptureMoveLegalInPosition(final ShogiPosition position, final CaptureMove move) {

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PawnMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PawnMovement.java
@@ -28,18 +28,12 @@ public class PawnMovement implements PieceMovement {
 
     @Override
     public boolean isDropValid(final ShogiBoardState position, final Square to) {
-        return to.getRow() != ShogiBoardState.FIRST_ROW && !position.hasPlayerPawnOnColumn(true, to.getColumn())
-                && !checkMatePawnMove(position, to);
+        return to.getRow() != ShogiBoardState.FIRST_ROW && !position.hasPlayerPawnOnColumn(true, to.getColumn());
     }
 
     @Override
     public boolean isUnpromoteValid(final ShogiBoardState position, final Square to) {
         return to.getRow() != ShogiBoardState.FIRST_ROW;
-    }
-
-    private boolean checkMatePawnMove(final ShogiBoardState position, final Square to) {
-        // TODO Auto-generated method stub
-        return false;
     }
 
 }

--- a/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/ShogiRulesEngineTest.java
+++ b/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/ShogiRulesEngineTest.java
@@ -6,6 +6,7 @@ import com.playshogi.library.shogi.models.formats.sfen.SfenConverter;
 import com.playshogi.library.shogi.models.moves.DropMove;
 import com.playshogi.library.shogi.models.moves.ShogiMove;
 import com.playshogi.library.shogi.models.position.ShogiPosition;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
@@ -14,9 +15,22 @@ import static org.junit.Assert.*;
 
 public class ShogiRulesEngineTest {
 
+    private ShogiRulesEngine engine;
+
+    @Before
+    public void setUp() {
+        engine = new ShogiRulesEngine();
+    }
+
+    @Test
+    public void isPawnDropLegalInPosition() {
+        String sfen = "lnsg1gsnl/7b1/prppppppp/kp7/9/2P6/NPBPPPPPP/7R1/L1SGKGSNL b P";
+        ShogiPosition position = SfenConverter.fromSFEN(sfen);
+        assertFalse("pawn drop checkmate", engine.isMoveLegalInPosition(position, new DropMove(true, PieceType.PAWN, Square.of(9, 5))));
+    }
+
     @Test
     public void isMoveLegalInPosition() {
-        ShogiRulesEngine engine = new ShogiRulesEngine();
         String sfen = "lnsg3nl/2k2gr2/ppbp1p1pp/2p1P4/4s1S2/5B3/PPPP1P1PP/2S1GGR2/LN4KNL b 2Pp";
         ShogiPosition position = SfenConverter.fromSFEN(sfen);
         assertTrue(engine.isMoveLegalInPosition(position, new DropMove(true, PieceType.PAWN, Square.of(3, 6))));
@@ -26,7 +40,6 @@ public class ShogiRulesEngineTest {
 
     @Test
     public void getAllPossibleDropMoves() {
-        ShogiRulesEngine engine = new ShogiRulesEngine();
         String sfen = "lnsg3nl/2k2gr2/ppbp1p1pp/2p1P4/4s1S2/5B3/PPPP1P1PP/2S1GGR2/LN4KNL b 2Pp";
         List<ShogiMove> allPossibleDropMoves = engine.getAllPossibleDropMoves(SfenConverter.fromSFEN(sfen), true);
         List<ShogiMove> allPossibleDropMoves2 = engine.getAllPossibleDropMoves(SfenConverter.fromSFEN(sfen), false);
@@ -38,7 +51,6 @@ public class ShogiRulesEngineTest {
 
     @Test
     public void getAllPossibleNormalAndCaptureMoves() {
-        ShogiRulesEngine engine = new ShogiRulesEngine();
         String sfen = "lnsg3nl/2k2gr2/ppbp1p1pp/2p1P4/4s1S2/5B3/PPPP1P1PP/2S1GGR2/LN4KNL b 2Pp";
         List<ShogiMove> allPossibleNormalAndCaptureMoves = engine.getAllPossibleNormalAndCaptureMoves(SfenConverter.fromSFEN(sfen), true);
         List<ShogiMove> allPossibleNormalAndCaptureMoves2 = engine.getAllPossibleNormalAndCaptureMoves(SfenConverter.fromSFEN(sfen), false);
@@ -50,7 +62,6 @@ public class ShogiRulesEngineTest {
 
     @Test
     public void isPositionCheck() {
-        ShogiRulesEngine engine = new ShogiRulesEngine();
         String sfen = "lnsg3nl/2k2gr2/ppbp1p1pp/2p1P4/4s1S2/5B3/PPPP1P1PP/2S1GGR2/LN4KNL b 2Pp";
         String sfenCheckmate = "4k4/4G4/4P4/9/9/9/9/9/9 w 2r2b3g4s4n4l17p";
         ShogiPosition position = SfenConverter.fromSFEN(sfen);
@@ -64,7 +75,6 @@ public class ShogiRulesEngineTest {
 
     @Test
     public void isPositionCheckmate() {
-        ShogiRulesEngine engine = new ShogiRulesEngine();
         String sfen = "lnsg3nl/2k2gr2/ppbp1p1pp/2p1P4/4s1S2/5B3/PPPP1P1PP/2S1GGR2/LN4KNL b 2Pp";
         String sfenCheckmate = "4k4/4G4/4P4/9/9/9/9/9/9 w 2r2b3g4s4n4l17p";
         String sfenOnlyCheck = "7k1/7G1/7P1/9/9/9/2b6/9/1K7 w -";


### PR DESCRIPTION
This patch might cause infinite recursion if both players are prune to pawn drop check/checkmate, since isPositionCheckmate() generates all legal moves.