### PR TITLE
Simplify knight and ranged piece movements, remove null return values

### DIFF
--- a/playshogi-library-common/src/main/java/com/playshogi/library/models/Square.java
+++ b/playshogi-library-common/src/main/java/com/playshogi/library/models/Square.java
@@ -2,6 +2,7 @@ package com.playshogi.library.models;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a square on the board. 1,1 is the top right, as in shogi.
@@ -27,28 +28,28 @@ public class Square {
         return new Square(column, row);
     }
 
-    public Square above() {
-        if (row == 1) return null;
+    public Optional<Square> above() {
+        if (row == 1) return Optional.empty();
 
-        return Square.of(column, row - 1);
+        return Optional.of(Square.of(column, row - 1));
     }
 
-    public Square below() {
-        if (row == 9) return null;
+    public Optional<Square> below() {
+        if (row == 9) return Optional.empty();
 
-        return Square.of(column, row + 1);
+        return Optional.of(Square.of(column, row + 1));
     }
 
-    public Square left() {
-        if (column == 9) return null;
+    public Optional<Square> left() {
+        if (column == 9) return Optional.empty();
 
-        return Square.of(column + 1, row);
+        return Optional.of(Square.of(column + 1, row));
     }
 
-    public Square right() {
-        if (column == 1) return null;
+    public Optional<Square> right() {
+        if (column == 1) return Optional.empty();
 
-        return Square.of(column - 1, row);
+        return Optional.of(Square.of(column - 1, row));
     }
 
     public Square opposite() {
@@ -88,4 +89,8 @@ public class Square {
         return true;
     }
 
+    @Override
+    public String toString() {
+        return column + String.valueOf(Character.toChars('a' + row - 1));
+    }
 }

--- a/playshogi-library-common/src/main/java/com/playshogi/library/models/Square.java
+++ b/playshogi-library-common/src/main/java/com/playshogi/library/models/Square.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 /**
  * Represents a square on the board. 1,1 is the top right, as in shogi.
  */
-public class Square {
+public class Square implements Comparable<Square> {
     private final int column;
     private final int row;
 
@@ -74,19 +74,19 @@ public class Square {
     }
 
     @Override
+    public int compareTo(Square s) {
+        if (column == s.column)
+            return row - s.row;
+        return column - s.column;
+    }
+
+    @Override
     public boolean equals(final Object obj) {
-        if (this == obj)
-            return true;
         if (obj == null)
             return false;
         if (getClass() != obj.getClass())
             return false;
-        Square other = (Square) obj;
-        if (column != other.column)
-            return false;
-        if (row != other.row)
-            return false;
-        return true;
+        return compareTo((Square) obj) == 0;
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/features/GoldAtHeadFeature.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/features/GoldAtHeadFeature.java
@@ -10,6 +10,8 @@ import com.playshogi.library.shogi.models.PieceType;
 import com.playshogi.library.shogi.models.moves.DropMove;
 import com.playshogi.library.shogi.models.position.ShogiPosition;
 
+import java.util.Optional;
+
 public enum GoldAtHeadFeature implements Feature {
     INSTANCE;
 
@@ -25,9 +27,9 @@ public enum GoldAtHeadFeature implements Feature {
                 DropMove dropMove = (DropMove) lastMove;
                 if (dropMove.getPieceType() == PieceType.GOLD) {
                     ShogiPosition position = gameNavigation.getPosition();
-                    Square aboveDropSquare = dropMove.getToSquare().above();
+                    Optional<Square> aboveDropSquare = dropMove.getToSquare().above();
                     // add sente's piece requirement and condition for sente king too.
-                    return aboveDropSquare != null && position.getPieceAt(aboveDropSquare) == Piece.GOTE_KING;
+                    return aboveDropSquare.isPresent() && position.getPieceAt(aboveDropSquare.get()).orElse(null) == Piece.GOTE_KING;
                 }
             }
         }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/formats/kif/KifMoveConverter.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/formats/kif/KifMoveConverter.java
@@ -6,6 +6,8 @@ import com.playshogi.library.shogi.models.formats.kif.KifUtils.PieceParsingResul
 import com.playshogi.library.shogi.models.moves.*;
 import com.playshogi.library.shogi.models.position.ShogiPosition;
 
+import java.util.Optional;
+
 public class KifMoveConverter {
 
     public static ShogiMove fromKifString(final String str, final ShogiPosition shogiPosition,
@@ -74,13 +76,12 @@ public class KifMoveConverter {
             int row2 = str.charAt(++pos) - '0';
             Square fromSquare = Square.of(column2, row2);
 
-            if (shogiPosition.getShogiBoardState().getPieceAt(toSquare) == null) {
-                return new NormalMove(piece, fromSquare, toSquare, promote);
+            Optional<Piece> capturedPiece = shogiPosition.getShogiBoardState().getPieceAt(toSquare);
+            if (capturedPiece.isPresent()) {
+                return new CaptureMove(piece, fromSquare, toSquare, capturedPiece.get(), promote);
             } else {
-                Piece capturedPiece = shogiPosition.getShogiBoardState().getPieceAt(toSquare);
-                return new CaptureMove(piece, fromSquare, toSquare, capturedPiece, promote);
+                return new NormalMove(piece, fromSquare, toSquare, promote);
             }
-
         } else {
             throw new IllegalArgumentException("Error reading the move " + str);
         }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/formats/sfen/SfenConverter.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/formats/sfen/SfenConverter.java
@@ -10,6 +10,8 @@ import com.playshogi.library.shogi.models.position.ShogiPosition;
 import static com.playshogi.library.shogi.models.formats.usf.UsfUtil.pieceFromChar;
 import static com.playshogi.library.shogi.models.formats.usf.UsfUtil.pieceToString;
 
+import java.util.Optional;
+
 public class SfenConverter {
 
     private static final PieceType[] PIECE_TYPE_VALUES = PieceType.values();
@@ -20,15 +22,15 @@ public class SfenConverter {
         // First, the pieces on board
         for (int i = 0; i < 9; i++) {
             for (int j = 0; j < 9; j++) {
-                Piece piece = pos.getShogiBoardState().getPieceAt(1 + (8 - j), 1 + i);
-                if (piece == null) {
-                    numspace++;
-                } else {
+                Optional<Piece> piece = pos.getShogiBoardState().getPieceAt(1 + (8 - j), 1 + i);
+                if (piece.isPresent()) {
                     if (numspace != 0) {
                         res += numspace;
                     }
                     numspace = 0;
-                    res += pieceToString(piece);
+                    res += pieceToString(piece.get());
+                } else {
+                    numspace++;
                 }
             }
             if (numspace != 0) {

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/formats/usf/UsfMoveConverter.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/formats/usf/UsfMoveConverter.java
@@ -5,6 +5,8 @@ import com.playshogi.library.shogi.models.Piece;
 import com.playshogi.library.shogi.models.moves.*;
 import com.playshogi.library.shogi.models.position.ShogiPosition;
 
+import java.util.Optional;
+
 public class UsfMoveConverter {
 
     public static final String[] specialStrings = {"", "DUMY", "SLNT", "RSGN", "BREK", "JISO", "TIME", "FOUL", "VICT",
@@ -46,7 +48,7 @@ public class UsfMoveConverter {
         } else {
             col1 = UsfUtil.char2ColumnNumber(usfMove.charAt(0));
             row1 = UsfUtil.char2RowNumber(usfMove.charAt(1));
-            piece = shogiPosition.getPieceAt(Square.of(col1, row1));
+            piece = shogiPosition.getPieceAt(Square.of(col1, row1)).orElse(null);
         }
         if (usfMove.charAt(3) == '*') {
             // TODO
@@ -60,11 +62,11 @@ public class UsfMoveConverter {
         if (drop) {
             return new DropMove(piece.isSentePiece(), piece.getPieceType(), Square.of(col2, row2));
         } else {
-            Piece capturedPiece = shogiPosition.getPieceAt(Square.of(col2, row2));
-            if (capturedPiece == null) {
-                return new NormalMove(piece, Square.of(col1, row1), Square.of(col2, row2), promotion);
+            Optional<Piece> capturedPiece = shogiPosition.getPieceAt(Square.of(col2, row2));
+            if (capturedPiece.isPresent()) {
+                return new CaptureMove(piece, Square.of(col1, row1), Square.of(col2, row2), capturedPiece.get(), promotion);
             } else {
-                return new CaptureMove(piece, Square.of(col1, row1), Square.of(col2, row2), capturedPiece, promotion);
+                return new NormalMove(piece, Square.of(col1, row1), Square.of(col2, row2), promotion);
             }
         }
     }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/position/InvertedShogiBoardState.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/position/InvertedShogiBoardState.java
@@ -3,6 +3,8 @@ package com.playshogi.library.shogi.models.position;
 import com.playshogi.library.models.Square;
 import com.playshogi.library.shogi.models.Piece;
 
+import java.util.Optional;
+
 class InvertedShogiBoardState extends ShogiBoardState {
     private final ShogiBoardState original;
 
@@ -11,13 +13,14 @@ class InvertedShogiBoardState extends ShogiBoardState {
     }
 
     @Override
-    public Piece getPieceAt(final int column, final int row) {
+    public Optional<Piece> getPieceAt(final int column, final int row) {
         return getPieceAt(Square.of(column, row));
     }
 
     @Override
-    public Piece getPieceAt(final Square square) {
-        return Piece.getOppositePiece(original.getPieceAt(square.opposite()));
+    public Optional<Piece> getPieceAt(final Square square) {
+        Optional<Piece> piece = original.getPieceAt(square.opposite());
+        return piece.map(Piece::opposite);
     }
 
     @Override
@@ -52,7 +55,7 @@ class InvertedShogiBoardState extends ShogiBoardState {
 
     @Override
     public boolean isSquareEmptyOrGote(final Square square) {
-        Piece piece = original.getPieceAt(square.opposite());
-        return piece == null || piece.isSentePiece();
+        Optional<Piece> piece = original.getPieceAt(square.opposite());
+        return !piece.isPresent() || piece.get().isSentePiece();
     }
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/position/ShogiBoardState.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/position/ShogiBoardState.java
@@ -4,14 +4,16 @@ import com.playshogi.library.models.Square;
 import com.playshogi.library.shogi.models.Piece;
 import com.playshogi.library.shogi.models.formats.usf.UsfUtil;
 
+import java.util.Optional;
+
 public abstract class ShogiBoardState {
 
     public static final int FIRST_ROW = 1;
     public static final int FIRST_COLUMN = 1;
 
-    public abstract Piece getPieceAt(int column, int row);
+    public abstract Optional<Piece> getPieceAt(int column, int row);
 
-    public abstract Piece getPieceAt(Square square);
+    public abstract Optional<Piece> getPieceAt(Square square);
 
     public abstract void setPieceAt(int column, int row, Piece piece);
 
@@ -38,25 +40,25 @@ public abstract class ShogiBoardState {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(600);
+        builder.append("\n  9  8  7  6  5  4  3  2  1\n");
         for (int row = FIRST_ROW; row <= getLastRow(); row++) {
             builder.append("----------------------------\n");
             for (int column = FIRST_COLUMN; column <= getLastColumn(); column++) {
                 builder.append('|');
-                Piece pieceAt = getPieceAt(10 - column, row);
-                if (pieceAt == null) {
-                    builder.append("  ");
-                } else {
-                    String pieceToString = UsfUtil.pieceToString(pieceAt);
+                Optional<Piece> pieceAt = getPieceAt(10 - column, row);
+                if (pieceAt.isPresent()) {
+                    String pieceToString = UsfUtil.pieceToString(pieceAt.get());
                     if (pieceToString.length() == 1) {
                         builder.append(' ');
                     }
                     builder.append(pieceToString);
+                } else {
+                    builder.append("  ");
                 }
             }
-            builder.append("|\n");
+            builder.append("| ").append(Character.toChars('a' + (row - FIRST_ROW))).append('\n');
         }
-
-        builder.append("----------------------------\n");
+        builder.append("----------------------------");
 
         return builder.toString();
     }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/position/ShogiBoardStateImpl.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/position/ShogiBoardStateImpl.java
@@ -4,6 +4,8 @@ import com.playshogi.library.models.Square;
 import com.playshogi.library.shogi.models.Piece;
 import com.playshogi.library.shogi.models.PieceType;
 
+import java.util.Optional;
+
 public class ShogiBoardStateImpl extends ShogiBoardState {
 
     private ShogiBoardState invert;
@@ -24,12 +26,12 @@ public class ShogiBoardStateImpl extends ShogiBoardState {
     }
 
     @Override
-    public Piece getPieceAt(final int column, final int row) {
-        return board[column - 1][row - 1];
+    public Optional<Piece> getPieceAt(final int column, final int row) {
+        return Optional.ofNullable(board[column - 1][row - 1]);
     }
 
     @Override
-    public Piece getPieceAt(final Square square) {
+    public Optional<Piece> getPieceAt(final Square square) {
         return getPieceAt(square.getColumn(), square.getRow());
     }
 
@@ -74,7 +76,7 @@ public class ShogiBoardStateImpl extends ShogiBoardState {
 
     @Override
     public boolean isSquareEmptyOrGote(final Square square) {
-        Piece piece = getPieceAt(square);
-        return piece == null || !piece.isSentePiece();
+        Optional<Piece> piece = getPieceAt(square);
+        return !piece.isPresent() || piece.get().isSentePiece();
     }
 }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/position/ShogiPosition.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/models/position/ShogiPosition.java
@@ -8,6 +8,7 @@ import com.playshogi.library.shogi.models.shogivariant.ShogiVariant;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class ShogiPosition implements Position<ShogiPosition> {
 
@@ -67,7 +68,7 @@ public class ShogiPosition implements Position<ShogiPosition> {
         this.goteKomadai = goteKomadai;
     }
 
-    public Piece getPieceAt(final Square square) {
+    public Optional<Piece> getPieceAt(final Square square) {
         return shogiBoardState.getPieceAt(square);
     }
 

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/ShogiRulesEngine.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/ShogiRulesEngine.java
@@ -269,7 +269,7 @@ public class ShogiRulesEngine implements GameRulesEngine<ShogiPosition> {
 
         for (Square square : position.getAllSquares()) { //for every square on the board
             Optional<Piece> piece = position.getPieceAt(square);
-            if (piece.filter(p -> p.isSentePiece() == isSente).isPresent()) {
+            if (piece.isPresent() && (piece.get().isSentePiece() == isSente)) {
                 //check if there is sente's piece
                 List<Square> targetSquares = getPossibleTargetSquares(position, square);
                 // find its possible squares to move
@@ -277,7 +277,7 @@ public class ShogiRulesEngine implements GameRulesEngine<ShogiPosition> {
                     Optional<Piece> targetPiece = position.getPieceAt(targetSquare);
                     NormalMove move;
                     if (targetPiece.isPresent()) { //check if it is a capturing move
-                        if (targetPiece.filter(p -> p.isSentePiece() == isSente).isPresent())
+                        if (targetPiece.get().isSentePiece() == isSente)
                             continue;
                         move = new CaptureMove(piece.get(), square, targetSquare, targetPiece.get());
                     } else {

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/AbstractPieceMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/AbstractPieceMovement.java
@@ -5,6 +5,7 @@ import com.playshogi.library.shogi.models.position.ShogiBoardState;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public abstract class AbstractPieceMovement implements PieceMovement {
 
@@ -19,10 +20,10 @@ public abstract class AbstractPieceMovement implements PieceMovement {
         List<Square> result = new ArrayList<>(allowedDColDRow.length);
 
         for (int[] dColRow : allowedDColDRow) {
-            Square square = PieceMovementsUtils.getSquare(boardState, from.getColumn() + dColRow[0],
+            Optional<Square> square = PieceMovementsUtils.getSquare(boardState, from.getColumn() + dColRow[0],
                     from.getRow() + dColRow[1]);
-            if (square != null && boardState.isSquareEmptyOrGote(square)) {
-                result.add(square);
+            if (square.isPresent() && boardState.isSquareEmptyOrGote(square.get())) {
+                result.add(square.get());
             }
         }
 

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/BishopMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/BishopMovement.java
@@ -20,7 +20,9 @@ public class BishopMovement implements PieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        return PieceMovementsUtils.isAlongDirection(boardState, from, to);
+        // Bishops move an equal number of squares horizontally and vertically
+        return (Math.abs(to.getColumn() - from.getColumn()) == Math.abs(to.getRow() - from.getRow()) &&
+                PieceMovementsUtils.isAlongDirection(boardState, from, to));
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/BishopMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/BishopMovement.java
@@ -10,7 +10,7 @@ public class BishopMovement implements PieceMovement {
 
     @Override
     public List<Square> getPossibleMoves(final ShogiBoardState boardState, final Square from) {
-        List<Square> result = new ArrayList<Square>();
+        List<Square> result = new ArrayList<>();
         PieceMovementsUtils.addSquaresAlongDirection(boardState, from, -1, -1, result);
         PieceMovementsUtils.addSquaresAlongDirection(boardState, from, -1, +1, result);
         PieceMovementsUtils.addSquaresAlongDirection(boardState, from, +1, -1, result);
@@ -20,9 +20,7 @@ public class BishopMovement implements PieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        int dRow = Math.abs(to.getRow() - from.getRow());
-        int dColumn = Math.abs(to.getColumn() - from.getColumn());
-        return dRow == dColumn && getPossibleMoves(boardState, from).contains(to);
+        return PieceMovementsUtils.isAlongDirection(boardState, from, to);
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/BishopMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/BishopMovement.java
@@ -20,8 +20,9 @@ public class BishopMovement implements PieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        // TODO write more efficient method?
-        return getPossibleMoves(boardState, from).contains(to);
+        int dRow = Math.abs(to.getRow() - from.getRow());
+        int dColumn = Math.abs(to.getColumn() - from.getColumn());
+        return dRow == dColumn && getPossibleMoves(boardState, from).contains(to);
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/KnightMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/KnightMovement.java
@@ -6,34 +6,12 @@ import com.playshogi.library.shogi.models.position.ShogiBoardState;
 import java.util.ArrayList;
 import java.util.List;
 
-public class KnightMovement implements PieceMovement {
+public class KnightMovement extends AbstractPieceMovement {
 
-    @Override
-    public List<Square> getPossibleMoves(final ShogiBoardState boardState, final Square from) {
-        List<Square> result = new ArrayList<>(2);
-        int toRow = from.getRow() - 2;
-        if (toRow < ShogiBoardState.FIRST_ROW) {
-            return result; //empty list
-        }
-        if (from.getColumn() != ShogiBoardState.FIRST_COLUMN) {
-            Square square = Square.of(from.getColumn() - 1, toRow);
-            if (boardState.isSquareEmptyOrGote(square)) {
-                result.add(square);
-            }
-        }
-        if (from.getColumn() != boardState.getWidth()) {
-            Square square = Square.of(from.getColumn() + 1, toRow);
-            if (boardState.isSquareEmptyOrGote(square)) {
-                result.add(square);
-            }
-        }
-        return result;
-    }
+    private static final int[][] KNIGHT_ALLOWED_DCOL_DROW = {{+1, -2}, {-1, -2}};
 
-    @Override
-    public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        return (from.getRow() == to.getRow() + 2)
-                && (from.getColumn() == to.getColumn() + 1 || from.getColumn() == to.getColumn() - 1);
+    public KnightMovement() {
+        super(KNIGHT_ALLOWED_DCOL_DROW);
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PawnMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PawnMovement.java
@@ -6,14 +6,15 @@ import com.playshogi.library.shogi.models.position.ShogiBoardState;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 public class PawnMovement implements PieceMovement {
 
     @Override
     public List<Square> getPossibleMoves(final ShogiBoardState position, final Square from) {
         if (from.getRow() != ShogiBoardState.FIRST_ROW) {
-            Piece piece = position.getPieceAt(from.getColumn(), from.getRow() - 1);
-            if (piece == null || !piece.isSentePiece()) {
+            Optional<Piece> piece = position.getPieceAt(from.getColumn(), from.getRow() - 1);
+            if (!piece.isPresent() || !piece.get().isSentePiece()) {
                 return Collections.singletonList(Square.of(from.getColumn(), from.getRow() - 1));
             }
         }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PieceMovementsUtils.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PieceMovementsUtils.java
@@ -19,21 +19,31 @@ public class PieceMovementsUtils {
         return addSquaresAlongDirection(boardState, from, dColumn, dRow, new ArrayList<>()).contains(to);
     }
 
+    /**
+     * Appends squares along the given direction to the given square list
+     * @param boardState Board which may have occupied squares
+     * @param from Origin square (not to be appended)
+     * @param dCol Horizontal step size
+     * @param dRow Vertical step size
+     * @param result Target list for append operation
+     * @return List of squares
+     */
     public static List<Square> addSquaresAlongDirection(final ShogiBoardState boardState, final Square from, final int dCol,
                                                 final int dRow, final List<Square> result) {
-        int row = from.getRow();
-        int col = from.getColumn();
-        Optional<Square> square;
+        if (dCol != 0 || dRow != 0) {
+            int row = from.getRow();
+            int col = from.getColumn();
+            Optional<Square> square;
 
-        while ((square = getSquare(boardState, col += dCol, row += dRow)).isPresent()) {
-            Optional<Piece> piece = boardState.getPieceAt(col, row);
-            if (piece.filter(Piece::isSentePiece).isPresent()) {
-                break;
-            }
-
-            result.add(square.get());
-            if (piece.isPresent() && !piece.get().isSentePiece()) {
-                break;
+            while ((square = getSquare(boardState, col += dCol, row += dRow)).isPresent()) {
+                Optional<Piece> piece = boardState.getPieceAt(col, row);
+                if (piece.filter(Piece::isSentePiece).isPresent()) {
+                    break;
+                }
+                result.add(square.get());
+                if (piece.isPresent() && !piece.get().isSentePiece()) {
+                    break;
+                }
             }
         }
         return result;

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PieceMovementsUtils.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PieceMovementsUtils.java
@@ -4,32 +4,37 @@ import com.playshogi.library.models.Square;
 import com.playshogi.library.shogi.models.Piece;
 import com.playshogi.library.shogi.models.position.ShogiBoardState;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 public class PieceMovementsUtils {
+    public static boolean isAlongDirection(final ShogiBoardState boardState, final Square from, final Square to) {
+        // If destination square is occupied by a friendly (sente) piece, destination square is invalid
+        if (boardState.getPieceAt(to).filter(Piece::isSentePiece).isPresent()) {
+            return false;
+        }
+        int dRow = Integer.compare(to.getRow(), from.getRow());
+        int dColumn = Integer.compare(to.getColumn(), from.getColumn());
+        return addSquaresAlongDirection(boardState, from, dColumn, dRow, new ArrayList<>()).contains(to);
+    }
+
     public static List<Square> addSquaresAlongDirection(final ShogiBoardState boardState, final Square from, final int dCol,
                                                 final int dRow, final List<Square> result) {
-        int row = from.getRow() + dRow;
-        int col = from.getColumn() + dCol;
-        Optional<Square> square = getSquare(boardState, col, row);
+        int row = from.getRow();
+        int col = from.getColumn();
+        Optional<Square> square;
 
-        while (square.isPresent()) {
+        while ((square = getSquare(boardState, col += dCol, row += dRow)).isPresent()) {
             Optional<Piece> piece = boardState.getPieceAt(col, row);
-
-            if (piece.isPresent() && piece.get().isSentePiece()) {
+            if (piece.filter(Piece::isSentePiece).isPresent()) {
                 break;
             }
 
             result.add(square.get());
-
             if (piece.isPresent() && !piece.get().isSentePiece()) {
                 break;
             }
-
-            row += dRow;
-            col += dCol;
-            square = getSquare(boardState, col, row);
         }
         return result;
     }

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PieceMovementsUtils.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PieceMovementsUtils.java
@@ -5,24 +5,25 @@ import com.playshogi.library.shogi.models.Piece;
 import com.playshogi.library.shogi.models.position.ShogiBoardState;
 
 import java.util.List;
+import java.util.Optional;
 
 public class PieceMovementsUtils {
-    public static void addSquaresAlongDirection(final ShogiBoardState boardState, final Square from, final int dCol,
+    public static List<Square> addSquaresAlongDirection(final ShogiBoardState boardState, final Square from, final int dCol,
                                                 final int dRow, final List<Square> result) {
         int row = from.getRow() + dRow;
         int col = from.getColumn() + dCol;
-        Square square = getSquare(boardState, col, row);
+        Optional<Square> square = getSquare(boardState, col, row);
 
-        while (square != null) {
-            Piece piece = boardState.getPieceAt(col, row);
+        while (square.isPresent()) {
+            Optional<Piece> piece = boardState.getPieceAt(col, row);
 
-            if (piece != null && piece.isSentePiece()) {
+            if (piece.isPresent() && piece.get().isSentePiece()) {
                 break;
             }
 
-            result.add(Square.of(col, row));
+            result.add(square.get());
 
-            if (piece != null && !piece.isSentePiece()) {
+            if (piece.isPresent() && !piece.get().isSentePiece()) {
                 break;
             }
 
@@ -30,14 +31,15 @@ public class PieceMovementsUtils {
             col += dCol;
             square = getSquare(boardState, col, row);
         }
+        return result;
     }
 
-    public static Square getSquare(final ShogiBoardState boardState, final int column, final int row) {
+    public static Optional<Square> getSquare(final ShogiBoardState boardState, final int column, final int row) {
         if (column >= ShogiBoardState.FIRST_COLUMN && column <= boardState.getWidth()
                 && row >= ShogiBoardState.FIRST_ROW && row <= boardState.getHeight()) {
-            return Square.of(column, row);
+            return Optional.of(Square.of(column, row));
         } else {
-            return null;
+            return Optional.empty();
         }
     }
 

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovement.java
@@ -25,8 +25,11 @@ public class PromotedBishopMovement extends AbstractPieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        return (Math.abs(to.getRow() - from.getRow()) + Math.abs(to.getColumn() - from.getColumn()) == 1) ||
-                PieceMovementsUtils.isAlongDirection(boardState, from, to);
+        // Bishops move an equal number of squares horizontally and vertically
+        if (Math.abs(to.getColumn() - from.getColumn()) + Math.abs(to.getRow() - from.getRow()) == 1)
+            return true;
+        return (Math.abs(to.getColumn() - from.getColumn()) == Math.abs(to.getRow() - from.getRow()) &&
+                PieceMovementsUtils.isAlongDirection(boardState, from, to));
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovement.java
@@ -25,9 +25,8 @@ public class PromotedBishopMovement extends AbstractPieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        int dRow = Math.abs(to.getRow() - from.getRow());
-        int dColumn = Math.abs(to.getColumn() - from.getColumn());
-        return (dRow + dColumn == 1 || dRow == dColumn) && getPossibleMoves(boardState, from).contains(to);
+        return (Math.abs(to.getRow() - from.getRow()) + Math.abs(to.getColumn() - from.getColumn()) == 1) ||
+                PieceMovementsUtils.isAlongDirection(boardState, from, to);
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovement.java
@@ -25,8 +25,9 @@ public class PromotedBishopMovement extends AbstractPieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        // TODO write more efficient method?
-        return getPossibleMoves(boardState, from).contains(to);
+        int dRow = Math.abs(to.getRow() - from.getRow());
+        int dColumn = Math.abs(to.getColumn() - from.getColumn());
+        return (dRow + dColumn == 1 || dRow == dColumn) && getPossibleMoves(boardState, from).contains(to);
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovement.java
@@ -25,9 +25,8 @@ public class PromotedRookMovement extends AbstractPieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        int dRow = Math.abs(to.getRow() - from.getRow());
-        int dColumn = Math.abs(to.getColumn() - from.getColumn());
-        return (dRow + dColumn == 2 || dRow == 0 || dColumn == 0) && getPossibleMoves(boardState, from).contains(to);
+        return (Math.abs(to.getRow() - from.getRow()) == 1 && Math.abs(to.getColumn() - from.getColumn()) == 1) ||
+                PieceMovementsUtils.isAlongDirection(boardState, from, to);
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovement.java
@@ -25,8 +25,9 @@ public class PromotedRookMovement extends AbstractPieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        // TODO write more efficient method?
-        return getPossibleMoves(boardState, from).contains(to);
+        int dRow = Math.abs(to.getRow() - from.getRow());
+        int dColumn = Math.abs(to.getColumn() - from.getColumn());
+        return (dRow + dColumn == 2 || dRow == 0 || dColumn == 0) && getPossibleMoves(boardState, from).contains(to);
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovement.java
@@ -25,7 +25,10 @@ public class PromotedRookMovement extends AbstractPieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        return (Math.abs(to.getRow() - from.getRow()) == 1 && Math.abs(to.getColumn() - from.getColumn()) == 1) ||
+        // Rooks move either horizontally or vertically
+        if (Math.abs(to.getColumn() - from.getColumn()) * Math.abs(to.getRow() - from.getRow()) == 1)
+            return true;
+        return (Math.abs(to.getColumn() - from.getColumn()) * Math.abs(to.getRow() - from.getRow()) == 0) &&
                 PieceMovementsUtils.isAlongDirection(boardState, from, to);
     }
 

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/RookMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/RookMovement.java
@@ -20,39 +20,9 @@ public class RookMovement implements PieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-
-        if (to.getColumn() == from.getColumn() && to.getRow() < from.getRow()) {
-            for (int row = from.getRow() - 1; row > to.getRow(); row--) {
-                if (boardState.getPieceAt(from.getColumn(), row) != null) {
-                    return false;
-                }
-            }
-            return true;
-        } else if (to.getColumn() == from.getColumn() && to.getRow() > from.getRow()) {
-            for (int row = from.getRow() + 1; row < to.getRow(); row++) {
-                if (boardState.getPieceAt(from.getColumn(), row) != null) {
-                    return false;
-                }
-            }
-            return true;
-        } else if (to.getColumn() < from.getColumn() && to.getRow() == from.getRow()) {
-            for (int col = from.getColumn() - 1; col > to.getColumn(); col--) {
-                if (boardState.getPieceAt(col, from.getRow()) != null) {
-                    return false;
-                }
-            }
-            return true;
-        } else if (to.getColumn() > from.getColumn() && to.getRow() == from.getRow()) {
-            for (int col = from.getColumn() + 1; col < to.getColumn(); col++) {
-                if (boardState.getPieceAt(col, from.getRow()) != null) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        return false;
-
+        int dRow = Math.abs(to.getRow() - from.getRow());
+        int dColumn = Math.abs(to.getColumn() - from.getColumn());
+        return (dRow == 0 || dColumn == 0) && getPossibleMoves(boardState, from).contains(to);
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/RookMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/RookMovement.java
@@ -20,7 +20,9 @@ public class RookMovement implements PieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        return PieceMovementsUtils.isAlongDirection(boardState, from, to);
+        // Rooks move either horizontally or vertically
+        return (Math.abs(to.getColumn() - from.getColumn()) * Math.abs(to.getRow() - from.getRow()) == 0) &&
+                PieceMovementsUtils.isAlongDirection(boardState, from, to);
     }
 
     @Override

--- a/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/RookMovement.java
+++ b/playshogi-library-shogi/src/main/java/com/playshogi/library/shogi/rules/movements/RookMovement.java
@@ -10,7 +10,7 @@ public class RookMovement implements PieceMovement {
 
     @Override
     public List<Square> getPossibleMoves(final ShogiBoardState boardState, final Square from) {
-        List<Square> result = new ArrayList<Square>();
+        List<Square> result = new ArrayList<>();
         PieceMovementsUtils.addSquaresAlongDirection(boardState, from, 0, -1, result);
         PieceMovementsUtils.addSquaresAlongDirection(boardState, from, 0, +1, result);
         PieceMovementsUtils.addSquaresAlongDirection(boardState, from, -1, 0, result);
@@ -20,9 +20,7 @@ public class RookMovement implements PieceMovement {
 
     @Override
     public boolean isMoveDxDyValid(final ShogiBoardState boardState, final Square from, final Square to) {
-        int dRow = Math.abs(to.getRow() - from.getRow());
-        int dColumn = Math.abs(to.getColumn() - from.getColumn());
-        return (dRow == 0 || dColumn == 0) && getPossibleMoves(boardState, from).contains(to);
+        return PieceMovementsUtils.isAlongDirection(boardState, from, to);
     }
 
     @Override

--- a/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/ShogiRulesEngineTest.java
+++ b/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/ShogiRulesEngineTest.java
@@ -26,6 +26,7 @@ public class ShogiRulesEngineTest {
     public void isPawnDropLegalInPosition() {
         String sfen = "lnsg1gsnl/7b1/prppppppp/kp7/9/2P6/NPBPPPPPP/7R1/L1SGKGSNL b P";
         ShogiPosition position = SfenConverter.fromSFEN(sfen);
+        System.out.println(position);
         assertFalse("pawn drop checkmate", engine.isMoveLegalInPosition(position, new DropMove(true, PieceType.PAWN, Square.of(9, 5))));
     }
 
@@ -33,44 +34,66 @@ public class ShogiRulesEngineTest {
     public void isMoveLegalInPosition() {
         String sfen = "lnsg3nl/2k2gr2/ppbp1p1pp/2p1P4/4s1S2/5B3/PPPP1P1PP/2S1GGR2/LN4KNL b 2Pp";
         ShogiPosition position = SfenConverter.fromSFEN(sfen);
+        System.out.println(position);
         assertTrue(engine.isMoveLegalInPosition(position, new DropMove(true, PieceType.PAWN, Square.of(3, 6))));
         assertFalse(engine.isMoveLegalInPosition(position, new DropMove(true, PieceType.PAWN, Square.of(5, 6))));
         assertFalse(engine.isMoveLegalInPosition(position, new DropMove(true, PieceType.PAWN, Square.of(5, 3))));
     }
 
     @Test
-    public void getAllPossibleDropMoves() {
+    public void getAllPossibleDropMovesForSente() {
         String sfen = "lnsg3nl/2k2gr2/ppbp1p1pp/2p1P4/4s1S2/5B3/PPPP1P1PP/2S1GGR2/LN4KNL b 2Pp";
-        List<ShogiMove> allPossibleDropMoves = engine.getAllPossibleDropMoves(SfenConverter.fromSFEN(sfen), true);
-        List<ShogiMove> allPossibleDropMoves2 = engine.getAllPossibleDropMoves(SfenConverter.fromSFEN(sfen), false);
-        System.out.println(allPossibleDropMoves);
-        System.out.println(allPossibleDropMoves2);
-        assertEquals(allPossibleDropMoves2.size(),10);
-        assertEquals(allPossibleDropMoves.size(),4);
+        ShogiPosition position = SfenConverter.fromSFEN(sfen);
+        System.out.println(position);
+        List<ShogiMove> allPossibleDropMoves = engine.getAllPossibleDropMoves(position, true);
+        System.out.println("Drops: " + allPossibleDropMoves);
+        assertEquals(4, allPossibleDropMoves.size());
+    }
+
+    @Test
+    public void getAllPossibleDropMovesForGote() {
+        String sfen = "lnsg3nl/2k2gr2/ppbp1p1pp/2p1P4/4s1S2/5B3/PPPP1P1PP/2S1GGR2/LN4KNL b 2Pp";
+        ShogiPosition position = SfenConverter.fromSFEN(sfen);
+        System.out.println(position);
+        List<ShogiMove> allPossibleDropMoves = engine.getAllPossibleDropMoves(position, false);
+        System.out.println("Drops: " + allPossibleDropMoves);
+        assertEquals(10, allPossibleDropMoves.size());
     }
 
     @Test
     public void getAllPossibleNormalAndCaptureMoves() {
         String sfen = "lnsg3nl/2k2gr2/ppbp1p1pp/2p1P4/4s1S2/5B3/PPPP1P1PP/2S1GGR2/LN4KNL b 2Pp";
-        List<ShogiMove> allPossibleNormalAndCaptureMoves = engine.getAllPossibleNormalAndCaptureMoves(SfenConverter.fromSFEN(sfen), true);
-        List<ShogiMove> allPossibleNormalAndCaptureMoves2 = engine.getAllPossibleNormalAndCaptureMoves(SfenConverter.fromSFEN(sfen), false);
+        ShogiPosition position = SfenConverter.fromSFEN(sfen);
+        System.out.println(position);
+        List<ShogiMove> allPossibleNormalAndCaptureMoves = engine.getAllPossibleNormalAndCaptureMoves(position, true);
+        System.out.println("Moves: " + allPossibleNormalAndCaptureMoves);
+        assertEquals(34, allPossibleNormalAndCaptureMoves.size());
+    }
+
+    @Test
+    public void getAllPossibleNormalAndCaptureMoves2() {
+        String sfen = "lnsg3nl/2k2gr2/ppbp1p1pp/2p1P4/4s1S2/5B3/PPPP1P1PP/2S1GGR2/LN4KNL b 2Pp";
+        ShogiPosition position = SfenConverter.fromSFEN(sfen);
+        System.out.println(position);
+        List<ShogiMove> allPossibleNormalAndCaptureMoves = engine.getAllPossibleNormalAndCaptureMoves(position, false);
         System.out.println(allPossibleNormalAndCaptureMoves);
-        System.out.println(allPossibleNormalAndCaptureMoves2);
-        assertEquals(allPossibleNormalAndCaptureMoves.size(),34);
-        assertEquals(allPossibleNormalAndCaptureMoves2.size(),38);
+        assertEquals(38, allPossibleNormalAndCaptureMoves.size());
     }
 
     @Test
     public void isPositionCheck() {
         String sfen = "lnsg3nl/2k2gr2/ppbp1p1pp/2p1P4/4s1S2/5B3/PPPP1P1PP/2S1GGR2/LN4KNL b 2Pp";
-        String sfenCheckmate = "4k4/4G4/4P4/9/9/9/9/9/9 w 2r2b3g4s4n4l17p";
         ShogiPosition position = SfenConverter.fromSFEN(sfen);
-        ShogiPosition position2 = SfenConverter.fromSFEN(sfenCheckmate);
         System.out.println(position);
-        System.out.println(position2);
         assertFalse(engine.isPositionCheck(position, true));
-        assertTrue(engine.isPositionCheck(position2, true));
+    }
 
+    @Test
+    public void isPositionCheckIfCheckmate() {
+        String sfenCheckmate = "4k4/4G4/4P4/9/9/9/9/9/9 w 2r2b3g4s4n4l17p";
+        ShogiPosition position = SfenConverter.fromSFEN(sfenCheckmate);
+        System.out.println(position);
+        assertTrue(engine.isPositionCheck(position, true));
     }
 
     @Test

--- a/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/movements/BishopMovementTest.java
+++ b/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/movements/BishopMovementTest.java
@@ -1,0 +1,32 @@
+package com.playshogi.library.shogi.rules.movements;
+
+import com.playshogi.library.models.Square;
+import com.playshogi.library.shogi.models.position.ShogiPosition;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BishopMovementTest {
+
+    ShogiPosition position;
+    BishopMovement bishopMovement;
+    boolean[][] expected = new boolean[9][9];
+
+    @Before
+    public void setUp() {
+        position = new ShogiPosition();
+        bishopMovement = new BishopMovement();
+        for (int r=1; r<=4; r++)
+            expected[4-r][4-r] = expected[4-r][4+r] = expected[4+r][4-r] = expected[4+r][4+r] = true;
+    }
+
+    @Test
+    public void testIsMoveDxDyValid() {
+        boolean[][] actual = new boolean[9][9];
+        Square from = Square.of(5, 5);
+        for (Square to : position.getAllSquares())
+            actual[to.getColumn() - 1][to.getRow() - 1] = bishopMovement.isMoveDxDyValid(position.getShogiBoardState(), from, to);
+        assertArrayEquals(expected, actual);
+    }
+}

--- a/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovementTest.java
+++ b/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/movements/PromotedBishopMovementTest.java
@@ -1,0 +1,34 @@
+package com.playshogi.library.shogi.rules.movements;
+
+import com.playshogi.library.models.Square;
+import com.playshogi.library.shogi.models.position.ShogiPosition;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class PromotedBishopMovementTest {
+
+    ShogiPosition position;
+    PromotedBishopMovement bishopMovement;
+    boolean[][] expected = new boolean[9][9];
+
+    @Before
+    public void setUp() {
+        position = new ShogiPosition();
+        bishopMovement = new PromotedBishopMovement();
+        for (int r=1; r<=1; r++)
+            expected[4-r][4] = expected[4+r][4] = expected[4][4-r] = expected[4][4+r] = true;
+        for (int r=1; r<=4; r++)
+            expected[4-r][4-r] = expected[4-r][4+r] = expected[4+r][4-r] = expected[4+r][4+r] = true;
+    }
+
+    @Test
+    public void testIsMoveDxDyValid() {
+        boolean[][] actual = new boolean[9][9];
+        Square from = Square.of(5, 5);
+        for (Square to : position.getAllSquares())
+            actual[to.getColumn() - 1][to.getRow() - 1] = bishopMovement.isMoveDxDyValid(position.getShogiBoardState(), from, to);
+        assertArrayEquals(expected, actual);
+    }
+}

--- a/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovementTest.java
+++ b/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/movements/PromotedRookMovementTest.java
@@ -1,0 +1,34 @@
+package com.playshogi.library.shogi.rules.movements;
+
+import com.playshogi.library.models.Square;
+import com.playshogi.library.shogi.models.position.ShogiPosition;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class PromotedRookMovementTest {
+
+    ShogiPosition position;
+    PromotedRookMovement bishopMovement;
+    boolean[][] expected = new boolean[9][9];
+
+    @Before
+    public void setUp() {
+        position = new ShogiPosition();
+        bishopMovement = new PromotedRookMovement();
+        for (int r=1; r<=1; r++)
+            expected[4-r][4-r] = expected[4-r][4+r] = expected[4+r][4-r] = expected[4+r][4+r] = true;
+        for (int r=1; r<=4; r++)
+            expected[4-r][4] = expected[4+r][4] = expected[4][4-r] = expected[4][4+r] = true;
+    }
+
+    @Test
+    public void testIsMoveDxDyValid() {
+        boolean[][] actual = new boolean[9][9];
+        Square from = Square.of(5, 5);
+        for (Square to : position.getAllSquares())
+            actual[to.getColumn() - 1][to.getRow() - 1] = bishopMovement.isMoveDxDyValid(position.getShogiBoardState(), from, to);
+        assertArrayEquals(expected, actual);
+    }
+}

--- a/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/movements/RookMovementTest.java
+++ b/playshogi-library-shogi/src/test/java/com/playshogi/library/shogi/rules/movements/RookMovementTest.java
@@ -1,0 +1,32 @@
+package com.playshogi.library.shogi.rules.movements;
+
+import com.playshogi.library.models.Square;
+import com.playshogi.library.shogi.models.position.ShogiPosition;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class RookMovementTest {
+
+    ShogiPosition position;
+    RookMovement bishopMovement;
+    boolean[][] expected = new boolean[9][9];
+
+    @Before
+    public void setUp() {
+        position = new ShogiPosition();
+        bishopMovement = new RookMovement();
+        for (int r=1; r<=4; r++)
+            expected[4-r][4] = expected[4+r][4] = expected[4][4-r] = expected[4][4+r] = true;
+    }
+
+    @Test
+    public void testIsMoveDxDyValid() {
+        boolean[][] actual = new boolean[9][9];
+        Square from = Square.of(5, 5);
+        for (Square to : position.getAllSquares())
+            actual[to.getColumn() - 1][to.getRow() - 1] = bishopMovement.isMoveDxDyValid(position.getShogiBoardState(), from, to);
+        assertArrayEquals(expected, actual);
+    }
+}

--- a/playshogi-website-gwt-mvn/src/main/java/com/playshogi/website/gwt/client/widget/board/ShogiBoard.java
+++ b/playshogi-website-gwt-mvn/src/main/java/com/playshogi/website/gwt/client/widget/board/ShogiBoard.java
@@ -268,7 +268,7 @@ public class ShogiBoard extends Composite implements ClickHandler {
     }
 
     private Piece getPiece(final int row, final int col) {
-        return position.getShogiBoardState().getPieceAt(getSquare(row, col));
+        return position.getShogiBoardState().getPieceAt(getSquare(row, col)).orElse(null);
     }
 
     private Square getSquare(final int row, final int col) {


### PR DESCRIPTION
I am curious whether it is possible to speed up builds and/or to simplify code.