### PR TITLE
Clean pro set and tsume importers

### DIFF
--- a/playshogi-library-database/src/main/java/com/playshogi/library/database/collections/proset/ProSetImporter.java
+++ b/playshogi-library-database/src/main/java/com/playshogi/library/database/collections/proset/ProSetImporter.java
@@ -29,17 +29,15 @@ public class ProSetImporter {
         Set<String> errors = new HashSet<>();
 
 
-//        for (int i = 1; i <= 77458; i++) {
         for (int i = 1; i <= 77458; i++) {
-            String fileName = PATH + "kif" + i + ".kif";
-            File file = new File(fileName);
+            String fileName = "kif" + i + ".kif";
+            File file = new File(PATH, fileName);
             if (file.exists() && file.length() > 10) {
                 total++;
-                System.out.println("Processing file " + fileName + " of length " + file.length());
+                System.out.println("Processing file " + file + " of length " + file.length());
                 try {
-                    processKifu(fileName, rep, setId, i, venueId);
+                    processKifu(file, rep, setId, i, venueId);
                     ok++;
-//                    System.out.println("Success");
                 } catch (Exception ex) {
                     ex.printStackTrace();
                     error++;
@@ -47,7 +45,7 @@ public class ProSetImporter {
                     break;
                 }
             } else {
-                System.out.println("Not found: " + fileName);
+                System.out.println("Not found: " + file);
             }
         }
 
@@ -61,10 +59,10 @@ public class ProSetImporter {
 
     }
 
-    private static void processKifu(final String fileName, final GameSetRepository repository, final int setId,
+    private static void processKifu(final File file, final GameSetRepository repository, final int setId,
                                     final int kifuId, final int venueId)
             throws IOException {
-        GameRecord gameRecord = GameRecordFileReader.read(KifFormat.INSTANCE, fileName, "windows-932");
+        GameRecord gameRecord = GameRecordFileReader.read(KifFormat.INSTANCE, file, "windows-932");
         // Currently handicap games return null
         if (gameRecord != null) {
             repository.addGameToGameSet(gameRecord, setId, venueId, "Pro Classic Games #" + kifuId, 1);

--- a/playshogi-library-database/src/main/java/com/playshogi/library/database/collections/tsume1/TsumeImporter.java
+++ b/playshogi-library-database/src/main/java/com/playshogi/library/database/collections/tsume1/TsumeImporter.java
@@ -51,14 +51,14 @@ public class TsumeImporter {
         for (PATH path : PATH.values()) {
             System.out.println("Processing path " + path.path);
             for (int i = path.min; i <= path.max; i++) {
-                String fileName = path.path + String.format("%0" + path.padding + "d", i) + ".kif";
-                File file = new File(fileName);
-                System.out.println("Trying file " + fileName);
+                String fileName =  String.format("%0" + path.padding + "d", i) + ".kif";
+                File file = new File(path.path, fileName);
+                System.out.println("Trying file " + file);
                 if (file.exists() && file.length() > 10) {
                     total++;
-                    System.out.println("Processing file " + fileName + " of length " + file.length());
+                    System.out.println("Processing file " + file + " of length " + file.length());
                     try {
-                        processTsume(fileName, rep, setId, i);
+                        processTsume(file, rep, setId, i);
                         ok++;
                     } catch (Exception ex) {
                         ex.printStackTrace();
@@ -66,6 +66,8 @@ public class TsumeImporter {
                         errors.add(fileName);
                         break;
                     }
+                } else {
+                    System.out.println("Not found: " + file);
                 }
             }
         }
@@ -82,10 +84,10 @@ public class TsumeImporter {
 
     }
 
-    private static void processTsume(final String fileName, final ProblemSetRepository repository, final int setId,
+    private static void processTsume(final File file, final ProblemSetRepository repository, final int setId,
                                      final int kifuId)
             throws IOException {
-        GameRecord gameRecord = GameRecordFileReader.read(KifFormat.INSTANCE, fileName);
+        GameRecord gameRecord = GameRecordFileReader.read(KifFormat.INSTANCE, file);
         repository.addProblemToProblemSet(gameRecord, setId, "Tsume #" + kifuId, 1, 1000,
                 PersistentProblem.ProblemType.TSUME);
         // System.out.println(UsfFormat.INSTANCE.write(gameRecord));

--- a/playshogi-library-shogi-files/src/main/java/com/playshogi/library/shogi/files/GameRecordFileReader.java
+++ b/playshogi-library-shogi-files/src/main/java/com/playshogi/library/shogi/files/GameRecordFileReader.java
@@ -10,14 +10,23 @@ import java.util.Scanner;
 public class GameRecordFileReader {
 
     public static GameRecord read(final GameRecordFormat gameRecordFormat, final String fileName) throws IOException {
-        try (Scanner scanner = new Scanner(new File(fileName))) {
+        return read(gameRecordFormat, new File(fileName));
+    }
+
+    public static GameRecord read(final GameRecordFormat gameRecordFormat, final File file) throws IOException {
+        try (Scanner scanner = new Scanner(file)) {
             return gameRecordFormat.read(new ScannerLineReader(scanner));
         }
     }
 
     public static GameRecord read(final GameRecordFormat gameRecordFormat, final String fileName, final String encoding)
             throws IOException {
-        try (Scanner scanner = new Scanner(new File(fileName), encoding)) {
+        return read(gameRecordFormat, new File(fileName), encoding);
+    }
+
+    public static GameRecord read(final GameRecordFormat gameRecordFormat, final File file, final String encoding)
+            throws IOException {
+        try (Scanner scanner = new Scanner(file, encoding)) {
             return gameRecordFormat.read(new ScannerLineReader(scanner));
         }
     }


### PR DESCRIPTION
Using strong data types such as java.io.File handles the case where I forget to put a delimiter at the end of my file path (directory).  I also took this opportunity to add some more logging.